### PR TITLE
Added an optional custom InfoWindowAdapter

### DIFF
--- a/library/src/com/twotoasters/clusterkraf/Clusterkraf.java
+++ b/library/src/com/twotoasters/clusterkraf/Clusterkraf.java
@@ -9,6 +9,7 @@ import android.os.AsyncTask;
 import android.os.Build;
 import android.os.Handler;
 
+import android.view.View;
 import com.google.android.gms.maps.CameraUpdate;
 import com.google.android.gms.maps.CameraUpdateFactory;
 import com.google.android.gms.maps.GoogleMap;
@@ -62,6 +63,7 @@ public class Clusterkraf {
 			map.setOnCameraChangeListener(innerCallbackListener.clusteringOnCameraChangeListener);
 			map.setOnMarkerClickListener(innerCallbackListener);
 			map.setOnInfoWindowClickListener(innerCallbackListener);
+            map.setInfoWindowAdapter(innerCallbackListener);
 		}
 
 		showAllClusters();
@@ -265,7 +267,7 @@ public class Clusterkraf {
 	}
 
 	private static class InnerCallbackListener implements ClusteringOnCameraChangeListener.Host, ClusterTransitionsAnimation.Host, OnMarkerClickListener,
-			OnInfoWindowClickListener {
+			OnInfoWindowClickListener, GoogleMap.InfoWindowAdapter {
 
 		private final WeakReference<Clusterkraf> clusterkrafRef;
 
@@ -435,7 +437,43 @@ public class Clusterkraf {
 			}
 
 		}
-	}
+
+        /**
+         * @see com.google.android.gms.maps.GoogleMap.InfoWindowAdapter
+         *      getInfoWindow(com.google.android.gms.maps.model.Marker)
+         */
+        @Override
+        public View getInfoWindow(Marker marker) {
+            View infoWindow = null;
+            Clusterkraf clusterkraf = clusterkrafRef.get();
+            if (clusterkraf != null) {
+                ClusterPoint clusterPoint = clusterkraf.currentClusterPointsByMarker.get(marker);
+                InfoWindowDownstreamAdapter infoWindowDownstreamAdapter = clusterkraf.options.getInfoWindowDownstreamAdapter();
+                if (infoWindowDownstreamAdapter != null) {
+                    infoWindow = infoWindowDownstreamAdapter.getInfoWindow(marker, clusterPoint);
+                }
+            }
+            return infoWindow; // Google Map will handle it when null
+        }
+
+        /**
+         * @see com.google.android.gms.maps.GoogleMap.InfoWindowAdapter
+         *      getInfoContents(com.google.android.gms.maps.model.Marker)
+         */
+        @Override
+        public View getInfoContents(Marker marker) {
+            View infoWindow = null;
+            Clusterkraf clusterkraf = clusterkrafRef.get();
+            if (clusterkraf != null) {
+                ClusterPoint clusterPoint = clusterkraf.currentClusterPointsByMarker.get(marker);
+                InfoWindowDownstreamAdapter infoWindowDownstreamAdapter = clusterkraf.options.getInfoWindowDownstreamAdapter();
+                if (infoWindowDownstreamAdapter != null) {
+                    infoWindow = infoWindowDownstreamAdapter.getInfoContents(marker, clusterPoint);
+                }
+            }
+            return infoWindow; // Google Map will handle it when null
+        }
+    }
 
 	abstract private class BaseClusteringTaskHost implements ClusteringTask.Host {
 

--- a/library/src/com/twotoasters/clusterkraf/InfoWindowDownstreamAdapter.java
+++ b/library/src/com/twotoasters/clusterkraf/InfoWindowDownstreamAdapter.java
@@ -1,0 +1,14 @@
+package com.twotoasters.clusterkraf;
+
+import android.view.View;
+import com.google.android.gms.maps.model.Marker;
+
+/**
+ * Created by rafa on 03/09/13.
+ */
+public interface InfoWindowDownstreamAdapter {
+
+    public View getInfoContents(Marker marker, ClusterPoint clusterPoint);
+
+    public View getInfoWindow(Marker marker, ClusterPoint clusterPoint);
+}

--- a/library/src/com/twotoasters/clusterkraf/Options.java
+++ b/library/src/com/twotoasters/clusterkraf/Options.java
@@ -59,6 +59,12 @@ public class Options {
 	 */
 	private OnInfoWindowClickDownstreamListener onInfoWindowClickDownstreamListener;
 
+    /**
+     * The InfoWindowDownstreamAdapter to receive callbacks when an info window
+     * needs to be displayed.
+     */
+    private InfoWindowDownstreamAdapter infoWindowDownstreamAdapter;
+
 	/**
 	 * When zooming to the bounds of a marker's backing ClusterPoint, zoom until
 	 * all of the points are at least this far from the edge of the GoogleMap's
@@ -219,7 +225,22 @@ public class Options {
 		this.onInfoWindowClickDownstreamListener = onInfoWindowClickDownstreamListener;
 	}
 
-	/**
+    /**
+     * @return the infoWindowDownstreamAdapter
+     */
+    public InfoWindowDownstreamAdapter getInfoWindowDownstreamAdapter() {
+        return this.infoWindowDownstreamAdapter;
+    }
+
+    /**
+     * @param infoWindowDownstreamAdapter
+     *            the infoWindowDownstreamAdapter to set
+     */
+    public void setInfoWindowDownstreamAdapter(InfoWindowDownstreamAdapter infoWindowDownstreamAdapter) {
+        this.infoWindowDownstreamAdapter = infoWindowDownstreamAdapter;
+    }
+
+    /**
 	 * @return the clusterClickBehavior
 	 */
 	ClusterClickBehavior getClusterClickBehavior() {


### PR DESCRIPTION
Added an optional custom InfoWindowAdapter that passes the ClusterPoint to its methods.

I needed to use an InfoWindowAdapter for the balloons, but the official Adapter only gives the Marker as parameter, and because of my layer architecture I couldn't do much with it. So I decided to use the same pattern that you use for other listeners, and it works like a charm.

I tried to mirror your code style and comments in case you want to merge this feature.
Awesome library, by the way ;)
