### PR TITLE
Add clusterEnabled to Options

### DIFF
--- a/library/src/com/twotoasters/clusterkraf/ClustersBuilder.java
+++ b/library/src/com/twotoasters/clusterkraf/ClustersBuilder.java
@@ -98,13 +98,17 @@ class ClustersBuilder {
 			clusteredPoints = new ArrayList<ClusterPoint>(relevantInputPointsList.size());
 			for (InputPoint point : relevantInputPointsList) {
 				boolean addedToExistingCluster = false;
-				for (ClusterPoint clusterPoint : clusteredPoints) {
-					if (clusterPoint.getPixelDistanceFrom(point) <= options.getPixelDistanceToJoinCluster()) {
-						clusterPoint.add(point);
-						addedToExistingCluster = true;
-						break;
+				
+				if (options.isClusterEnabled()) {
+					for (ClusterPoint clusterPoint : clusteredPoints) {
+						if (clusterPoint.getPixelDistanceFrom(point) <= options.getPixelDistanceToJoinCluster()) {
+							clusterPoint.add(point);
+							addedToExistingCluster = true;
+							break;
+						}
 					}
 				}
+				
 				if (addedToExistingCluster == false) {
 					clusteredPoints.add(new ClusterPoint(point, projection, false));
 				}

--- a/library/src/com/twotoasters/clusterkraf/Options.java
+++ b/library/src/com/twotoasters/clusterkraf/Options.java
@@ -43,6 +43,11 @@ public class Options {
 	private double expandBoundsFactor = DEFAULT_EXPAND_BOUNDS_FACTOR;
 
 	/**
+	 * Enable or disable clustering
+	 */
+	private boolean clusterEnabled = true;
+	
+	/**
 	 * The MarkerOptionsChooser to use for customizing MarkerOptions objects.
 	 */
 	private MarkerOptionsChooser markerOptionsChooser;
@@ -116,7 +121,21 @@ public class Options {
 	/**
 	 * 
 	 */
-	private ProcessingListener processingListener;
+	private ProcessingListener processingListener;	
+	
+	/**
+	 * @return clusterEnabled
+	 */
+	public boolean isClusterEnabled() {
+		return clusterEnabled;
+	}
+
+	/**
+	 * @param clusterEnabled
+	 */
+	public void setClusterEnabled(boolean clusterEnabled) {
+		this.clusterEnabled = clusterEnabled;
+	}
 
 	/**
 	 * @return the transitionDuration


### PR DESCRIPTION
Hello,

Thank you for this awesome library. 

When I use it in my app, some of the points are very near to each other, so when user clicks on the cluster, the cluster does not expand to individual pins. 

So I add an option to disable clustering. In my app, whenever zoom exceed some certain level, I just disable clustering so user can access individual pins.

``` java
    @Override
    public void onClusteringStarted() {
        if (map == null) {
            return;
        }
        if (map.getCameraPosition().zoom >= 15) {
            options.setClusterEnabled(false);
        } else {
            options.setClusterEnabled(true);
        }
    }
```
