### PR TITLE
Clusterkraf.java updated to prevent NPE.

### DIFF
--- a/library/src/com/twotoasters/clusterkraf/Clusterkraf.java
+++ b/library/src/com/twotoasters/clusterkraf/Clusterkraf.java
@@ -140,7 +140,7 @@ public class Clusterkraf {
 		}
 		
 		currentClusters = null;
-		currentClusterPointsByMarker = null;
+		currentClusterPointsByMarker = new HashMap<Marker, ClusterPoint>();
 		currentMarkers = null;
 		previousClusters = null;
 		previousMarkers = null;


### PR DESCRIPTION
When user calls 'clear' function 'currentClusterPointsByMarker' nullified and this action sometimes causes NPE on 354 line.
